### PR TITLE
HADotNet - adding automations api

### DIFF
--- a/HADotNet.Core.Tests/AutomationTests.cs
+++ b/HADotNet.Core.Tests/AutomationTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HADotNet.Core;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Models;
+using NUnit.Framework;
+
+namespace Tests
+{
+    /// <summary>
+    /// The tests for <see cref="AutomationClient"/>.
+    /// </summary>
+    public class AutomationTests
+    {
+        private Uri Instance { get; set; }
+        private string ApiKey { get; set; }
+        private string AutomationId { get; set; }
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            // arrange
+            AutomationId = Guid.NewGuid().ToString();
+            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+
+            ClientFactory.Initialize(Instance, ApiKey);
+
+            var client = ClientFactory.GetClient<AutomationClient>();
+
+            var automation = new AutomationObject
+            {
+                Id = AutomationId,
+                Alias = $"test_automation_{AutomationId}",
+                Description = $"This is a test automation {DateTime.Now.ToLongDateString()}",
+                Actions = new List<Dictionary<string, object>>() 
+                { 
+                    new Dictionary<string, object>()
+                    {
+                        { "entity_id",  "switch.switch" },
+                        { "service", "switch.turn_on" }
+                    }
+                }
+            };
+
+            // act
+            var result = await client.Create(automation);
+            
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("ok", result.Result);
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDown()
+        {
+            // arrange
+            var client = ClientFactory.GetClient<AutomationClient>();
+
+            // act
+            var result = await client.Delete(AutomationId);
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("ok", result.Result);
+        }
+
+        [Test]
+        public async Task ShouldRetrieveAutomationById()
+        {
+            // arrange
+            var client = ClientFactory.GetClient<AutomationClient>();
+
+            // act
+            var automation = await client.Get(AutomationId);
+
+            // assert
+            Assert.IsNotNull(automation);
+        }
+
+        [Test]
+        public async Task ShouldUpdateAutomation()
+        {
+            // arrange
+            var automation = new AutomationObject
+            {
+                Id = AutomationId,
+                Actions = new List<Dictionary<string, object>>()
+                {
+                    new Dictionary<string, object>()
+                    {
+                        { "entity_id",  "switch.switch" },
+                        { "service", "switch.turn_off" }
+                    }
+                }
+            };
+
+            var client = ClientFactory.GetClient<AutomationClient>();
+
+            // act
+            var result = await client.Update(automation);
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("ok", result.Result);
+        }
+    }
+}

--- a/HADotNet.Core/BaseClient.cs
+++ b/HADotNet.Core/BaseClient.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
 
 namespace HADotNet.Core
 {
@@ -25,7 +24,6 @@ namespace HADotNet.Core
         protected BaseClient(Uri instance, string apiKey)
         {
             Client = new RestClient(instance);
-            Client.UseNewtonsoftJson();
             Client.AddDefaultHeader("Authorization", $"Bearer {apiKey}");
         }
 
@@ -104,7 +102,7 @@ namespace HADotNet.Core
 
             var resp = await Client.ExecuteTaskAsync(req);
 
-            if (!string.IsNullOrWhiteSpace(resp.Content) && (resp.StatusCode == HttpStatusCode.OK || resp.StatusCode == HttpStatusCode.Created))
+            if (!string.IsNullOrWhiteSpace(resp.Content) && (resp.StatusCode == HttpStatusCode.OK || resp.StatusCode == HttpStatusCode.NoContent))
             {
                 // Weird case for strings - return as-is
                 if (typeof(T).IsAssignableFrom(typeof(string)))
@@ -116,6 +114,22 @@ namespace HADotNet.Core
             }
 
             throw new Exception($"Unexpected response code {(int)resp.StatusCode} from Home Assistant API endpoint {path}.");
+        }
+
+        /// <summary>
+        /// Performs a DELETE request on the specified path.
+        /// </summary>
+        /// <param name="path">The relative API endpoint path.</param>
+        protected async Task Delete(string path)
+        {
+            var req = new RestRequest(path, Method.DELETE);
+
+            var resp = await Client.ExecuteTaskAsync(req);
+
+            if (!(resp.StatusCode == HttpStatusCode.OK || resp.StatusCode == HttpStatusCode.NoContent))
+            {
+                throw new Exception($"Unexpected response code {(int)resp.StatusCode} from Home Assistant API endpoint {path}.");
+            }
         }
     }
 }

--- a/HADotNet.Core/Clients/AutomationClient.cs
+++ b/HADotNet.Core/Clients/AutomationClient.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using HADotNet.Core.Models;
+
+namespace HADotNet.Core.Clients
+{
+    /// <summary>
+    /// Provides access to the automations API for working with automations.
+    /// </summary>
+    public class AutomationClient : BaseClient
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutomationClient" />.
+        /// </summary>
+        /// <param name="instance">The Home Assistant base instance URL.</param>
+        /// <param name="apiKey">The Home Assistant long-lived access token.</param>
+        public AutomationClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+
+        /// <summary>
+        /// Create the <see cref="AutomationObject"/>.
+        /// </summary>
+        /// <param name="automation">The <see cref="AutomationObject"/>.</param>
+        /// <returns>The <see cref="AutomationResultObject"/>.</returns>
+        public async Task<AutomationResultObject> Create(AutomationObject automation) => await Post<AutomationResultObject>($"/api/config/automation/config/{automation.Id}", automation);
+
+        /// <summary>
+        /// Read the <see cref="AutomationObject"/>.
+        /// </summary>
+        /// <param name="id">The automation id.</param>
+        /// <returns>The <see cref="AutomationObject"/>.</returns>
+        public async Task<AutomationObject> Get(string id) => await Get<AutomationObject>($"/api/config/automation/config/{id}");
+
+        /// <summary>
+        /// Update the <see cref="AutomationObject"/>.
+        /// </summary>
+        /// <param name="automation">The <see cref="AutomationObject"/>.</param>
+        /// <returns>The <see cref="AutomationResultObject"/>.</returns>
+        public async Task<AutomationResultObject> Update(AutomationObject automation) => await this.Create(automation);
+
+        /// <summary>
+        /// Delete the <see cref="AutomationObject"/>.
+        /// </summary>
+        /// <param name="id">The automation id.</param>
+        /// <returns>The <see cref="AutomationResultObject"/>.</returns>
+        public async Task<AutomationResultObject> Delete(string id) => await Delete<AutomationResultObject>($"/api/config/automation/config/{id}");
+    }
+}

--- a/HADotNet.Core/Clients/AutomationClient.cs
+++ b/HADotNet.Core/Clients/AutomationClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using HADotNet.Core.Models;
+using Newtonsoft.Json;
 
 namespace HADotNet.Core.Clients
 {
@@ -21,7 +22,7 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="automation">The <see cref="AutomationObject"/>.</param>
         /// <returns>The <see cref="AutomationResultObject"/>.</returns>
-        public async Task<AutomationResultObject> Create(AutomationObject automation) => await Post<AutomationResultObject>($"/api/config/automation/config/{automation.Id}", automation);
+        public async Task<AutomationResultObject> Create(AutomationObject automation) => await Post<AutomationResultObject>($"/api/config/automation/config/{automation.Id}", JsonConvert.SerializeObject(automation));
 
         /// <summary>
         /// Read the <see cref="AutomationObject"/>.

--- a/HADotNet.Core/HADotNet.Core.csproj
+++ b/HADotNet.Core/HADotNet.Core.csproj
@@ -32,7 +32,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.10.0" />
+    <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="106.10.1" />
   </ItemGroup>
 </Project>

--- a/HADotNet.Core/HADotNet.Core.csproj
+++ b/HADotNet.Core/HADotNet.Core.csproj
@@ -34,6 +34,5 @@
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="106.10.1" />
   </ItemGroup>
 </Project>

--- a/HADotNet.Core/Models/AutomationObject.cs
+++ b/HADotNet.Core/Models/AutomationObject.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace HADotNet.Core.Models
+{
+    /// <summary>
+    /// Represents automation object.
+    /// </summary>
+    public class AutomationObject
+    {
+        /// <summary>
+        /// Gets or sets the ID.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the alias.
+        /// </summary>
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actions.
+        /// </summary>
+        [JsonProperty("action")]
+        public List<Dictionary<string, object>> Actions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the conditions.
+        /// </summary>
+        [JsonProperty("condition")]
+        public List<Dictionary<string, object>> Conditions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the triggers.
+        /// </summary>
+        [JsonProperty("trigger")]
+        public List<Dictionary<string, object>> Triggers { get; set; } = new List<Dictionary<string, object>>();
+    }
+}

--- a/HADotNet.Core/Models/AutomationResultObject.cs
+++ b/HADotNet.Core/Models/AutomationResultObject.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace HADotNet.Core.Models
+{
+    /// <summary>
+    /// Represents the automation result.
+    /// </summary>
+    public class AutomationResultObject
+    {
+        /// <summary>
+        /// Gets or sets the automation result.
+        /// </summary>
+        [JsonProperty("result")]
+        public string Result { get; set; }
+    }
+}


### PR DESCRIPTION
Hi Jake,

Hope you are doing well.

I was working with some code related to Automations in Home Assistant and added some code that  might be helpful for the package consumers. 

Here are a couple of comments about the changes:
1) For BaseClient I'm adding `Client.UseNewtonsoftJson();` call in constructor - I think it is necessary so that objects send via BaseClient are serialized properly by applying `[JsonProperty]` attributes that Models have. There might be other [serializers](http://restsharp.org/usage/serialization.html#default-serializers) applied - but I thought as long as `[JsonProperty]` attributes are used, it makes sense at least for now to stick to `NewtonsoftJson`;

Please let me know if you have any comments or concerns about my changes - I would be glad to communicate the changes and adjust of needed.

Thanks
