### PR TITLE
Refactor BaseClient for improved RestSharp use

### DIFF
--- a/HADotNet.Core/HADotNet.Core.csproj
+++ b/HADotNet.Core/HADotNet.Core.csproj
@@ -32,7 +32,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.11.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi Jake,

Hope this email finds you and your family well these strange days...

After 118 Home Assistant release RestSharp library stopped working. I looked into the issue and the RestSharp was complaining about unsupported compression type from Home Assistant. When looking at the responses - I didn't mention anything aother than Python version change:
![image](https://user-images.githubusercontent.com/7044304/103271846-fdc61680-49c3-11eb-9d8f-93b5234c7e40.png)

I also checked more recent versions of RestSharp (106.11.7 and 106.11.8-alpha.0.12) - still doesn't work...

So not to invent a wheel I switched to basic HttpClient which works fine and doesn't require any significant changes to the code.

Would you please take a look and let me know if you have some comments/concerns about the changes.

Thanks