### PR TITLE
HADotNet - using IHttpClientFactory

### DIFF
--- a/HADotNet.Core.Tests/AutomationTests.cs
+++ b/HADotNet.Core.Tests/AutomationTests.cs
@@ -1,9 +1,10 @@
-﻿using HADotNet.Core.Clients;
-using HADotNet.Core.Models;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Models;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
@@ -12,8 +13,7 @@ namespace HADotNet.Core.Tests
     /// </summary>
     public class AutomationTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private AutomationClient Client;
         private string AutomationId { get; set; }
 
         [OneTimeSetUp]
@@ -21,12 +21,12 @@ namespace HADotNet.Core.Tests
         {
             // arrange
             AutomationId = Guid.NewGuid().ToString();
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
 
-            var client = ClientFactory.GetClient<AutomationClient>();
+            Client = ClientFactory.GetClient<AutomationClient>();
 
             var automation = new AutomationObject
             {
@@ -44,7 +44,7 @@ namespace HADotNet.Core.Tests
             };
 
             // act
-            var result = await client.Create(automation);
+            var result = await Client.Create(automation);
             
             // assert
             Assert.IsNotNull(result);
@@ -54,11 +54,8 @@ namespace HADotNet.Core.Tests
         [OneTimeTearDown]
         public async Task OneTimeTearDown()
         {
-            // arrange
-            var client = ClientFactory.GetClient<AutomationClient>();
-
             // act
-            var result = await client.Delete(AutomationId);
+            var result = await Client.Delete(AutomationId);
 
             // assert
             Assert.IsNotNull(result);
@@ -68,11 +65,8 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveAutomationById()
         {
-            // arrange
-            var client = ClientFactory.GetClient<AutomationClient>();
-
             // act
-            var automation = await client.Get(AutomationId);
+            var automation = await Client.Get(AutomationId);
 
             // assert
             Assert.IsNotNull(automation);
@@ -97,10 +91,8 @@ namespace HADotNet.Core.Tests
                 }
             };
 
-            var client = ClientFactory.GetClient<AutomationClient>();
-
             // act
-            var result = await client.Update(automation);
+            var result = await Client.Update(automation);
 
             // assert
             Assert.IsNotNull(result);

--- a/HADotNet.Core.Tests/CalendarTests.cs
+++ b/HADotNet.Core.Tests/CalendarTests.cs
@@ -1,30 +1,30 @@
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class CalendarTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private CalendarClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<CalendarClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveCalendarItemsForDays()
         {
-            var client = ClientFactory.GetClient<CalendarClient>();
-
-            var events = await client.GetEvents("mycalendar");
+            var events = await Client.GetEvents("mycalendar");
 
             Assert.IsNotNull(events);
             Assert.AreNotEqual(0, events.Count);
@@ -33,9 +33,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveCalendarItemsForTimeRange()
         {
-            var client = ClientFactory.GetClient<CalendarClient>();
-
-            var events = await client.GetEvents("mycalendar", DateTimeOffset.Now.Subtract(TimeSpan.FromDays(30)), DateTimeOffset.Now.AddDays(90));
+            var events = await Client.GetEvents("mycalendar", DateTimeOffset.Now.Subtract(TimeSpan.FromDays(30)), DateTimeOffset.Now.AddDays(90));
 
             Assert.IsNotNull(events);
             Assert.AreNotEqual(0, events.Count);

--- a/HADotNet.Core.Tests/ConfigTests.cs
+++ b/HADotNet.Core.Tests/ConfigTests.cs
@@ -1,30 +1,30 @@
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class ConfigTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private ConfigClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<ConfigClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveConfiguration()
         {
-            var client = ClientFactory.GetClient<ConfigClient>();
-
-            var config = await client.GetConfiguration();
+            var config = await Client.GetConfiguration();
 
             Assert.IsNotNull(config);
             Assert.IsNotNull(config.UnitSystem);

--- a/HADotNet.Core.Tests/DiscoveryTests.cs
+++ b/HADotNet.Core.Tests/DiscoveryTests.cs
@@ -1,30 +1,30 @@
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class DiscoveryTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private DiscoveryClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<DiscoveryClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveDiscoveryInfo()
         {
-            var client = ClientFactory.GetClient<DiscoveryClient>();
-
-            var discovery = await client.GetDiscoveryInfo();
+            var discovery = await Client.GetDiscoveryInfo();
 
             Assert.IsNotNull(discovery);
             Assert.IsNotEmpty(discovery.LocationName);

--- a/HADotNet.Core.Tests/EntityTests.cs
+++ b/HADotNet.Core.Tests/EntityTests.cs
@@ -1,32 +1,31 @@
-using HADotNet.Core;
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class EntityTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private EntityClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<EntityClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveEntityList()
         {
-            var client = ClientFactory.GetClient<EntityClient>();
-
-            var entities = await client.GetEntities();
+            var entities = await Client.GetEntities();
 
             Assert.IsNotNull(entities);
             Assert.AreNotEqual(0, entities.Count());

--- a/HADotNet.Core.Tests/ErrorLogTests.cs
+++ b/HADotNet.Core.Tests/ErrorLogTests.cs
@@ -1,31 +1,30 @@
-using HADotNet.Core;
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class ErrorLogTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private ErrorLogClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<ErrorLogClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveErrorLogList()
         {
-            var client = ClientFactory.GetClient<ErrorLogClient>();
-
-            var log = await client.GetErrorLogEntries();
+            var log = await Client.GetErrorLogEntries();
 
             Assert.IsNotNull(log);
             Assert.AreNotEqual(0, log.LogEntries.Count);

--- a/HADotNet.Core.Tests/EventTests.cs
+++ b/HADotNet.Core.Tests/EventTests.cs
@@ -1,31 +1,30 @@
-using HADotNet.Core;
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class EventTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private EventClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<EventClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveEventList()
         {
-            var client = ClientFactory.GetClient<EventClient>();
-
-            var events = await client.GetEvents();
+            var events = await Client.GetEvents();
 
             Assert.IsNotNull(events);
             Assert.AreNotEqual(0, events.Count);

--- a/HADotNet.Core.Tests/HADotNet.Core.Tests.csproj
+++ b/HADotNet.Core.Tests/HADotNet.Core.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="nunit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/HADotNet.Core.Tests/HistoryTests.cs
+++ b/HADotNet.Core.Tests/HistoryTests.cs
@@ -1,31 +1,30 @@
-using HADotNet.Core;
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class HistoryTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private HistoryClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<HistoryClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveAllHistory()
         {
-            var client = ClientFactory.GetClient<HistoryClient>();
-
-            var allHistory = await client.GetHistory();
+            var allHistory = await Client.GetHistory();
 
             Assert.IsNotNull(allHistory);
             Assert.IsNotEmpty(allHistory[0].EntityId);
@@ -36,9 +35,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveHistoryByEntityId()
         {
-            var client = ClientFactory.GetClient<HistoryClient>();
-
-            var history = await client.GetHistory("light.jakes_office");
+            var history = await Client.GetHistory("light.jakes_office");
 
             Assert.IsNotNull(history);
             Assert.IsNotEmpty(history.EntityId);
@@ -48,9 +45,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveHistoryByStartDate()
         {
-            var client = ClientFactory.GetClient<HistoryClient>();
-
-            var allHistory = await client.GetHistory(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)));
+            var allHistory = await Client.GetHistory(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)));
 
             Assert.IsNotNull(allHistory);
             Assert.IsNotEmpty(allHistory[0].EntityId);
@@ -61,9 +56,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveHistoryByStartAndEndDate()
         {
-            var client = ClientFactory.GetClient<HistoryClient>();
-
-            var allHistory = await client.GetHistory(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
+            var allHistory = await Client.GetHistory(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
 
             Assert.IsNotNull(allHistory);
             Assert.IsNotEmpty(allHistory[0].EntityId);
@@ -74,9 +67,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveHistoryByStartDateAndDuration()
         {
-            var client = ClientFactory.GetClient<HistoryClient>();
-
-            var allHistory = await client.GetHistory(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), TimeSpan.FromHours(18));
+            var allHistory = await Client.GetHistory(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), TimeSpan.FromHours(18));
 
             Assert.IsNotNull(allHistory);
             Assert.IsNotEmpty(allHistory[0].EntityId);
@@ -87,9 +78,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveHistoryByStartAndEndDateAndEntityId()
         {
-            var client = ClientFactory.GetClient<HistoryClient>();
-
-            var history = await client.GetHistory("group.family_room_lights", DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
+            var history = await Client.GetHistory("group.family_room_lights", DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
 
             Assert.IsNotNull(history);
             Assert.IsNotEmpty(history.EntityId);

--- a/HADotNet.Core.Tests/InfoTests.cs
+++ b/HADotNet.Core.Tests/InfoTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using HADotNet.Core.Clients;
-using HADotNet.Core.Domain;
+using HADotNet.Core.Tests.Infrastructure;
 using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
@@ -15,27 +15,26 @@ namespace HADotNet.Core.Tests
     /// </remarks>
     public class InfoTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private InfoClient Client;
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<InfoClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveSupervisorInfo()
         {
-            var client = ClientFactory.GetClient<InfoClient>();
-
 #if TEST_ENV_HA_CORE
             Assert.ThrowsAsync<SupervisorNotFoundException>(async () => await client.GetSupervisorInfo());
 #else
-            var info = await client.GetSupervisorInfo();
+            var info = await Client.GetSupervisorInfo();
 
             Assert.AreEqual("ok", info.Result);
             Assert.IsNotNull(info.Data);
@@ -46,12 +45,10 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveHostInfo()
         {
-            var client = ClientFactory.GetClient<InfoClient>();
-
 #if TEST_ENV_HA_CORE
             Assert.ThrowsAsync<SupervisorNotFoundException>(async () => await client.GetHostInfo());
 #else
-            var info = await client.GetHostInfo();
+            var info = await Client.GetHostInfo();
 
             Assert.AreEqual("ok", info.Result);
             Assert.IsNotNull(info.Data);
@@ -62,12 +59,10 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveCoreInfo()
         {
-            var client = ClientFactory.GetClient<InfoClient>();
-
 #if TEST_ENV_HA_CORE
             Assert.ThrowsAsync<SupervisorNotFoundException>(async () => await client.GetCoreInfo());
 #else
-            var info = await client.GetCoreInfo();
+            var info = await Client.GetCoreInfo();
 
             Assert.AreEqual("ok", info.Result);
             Assert.IsNotNull(info.Data);

--- a/HADotNet.Core.Tests/Infrastructure/DefaultHttpClientFactory.cs
+++ b/HADotNet.Core.Tests/Infrastructure/DefaultHttpClientFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Net.Http;
+
+namespace HADotNet.Core.Tests.Infrastructure
+{
+    public sealed class DefaultHttpClientFactory : IHttpClientFactory
+    {
+        private static readonly Lazy<IHttpClientFactory> _httpClientFactoryLazy =
+            new Lazy<IHttpClientFactory>(() => new DefaultHttpClientFactory());
+
+        private static readonly Lazy<HttpClient> _httpClientLazy =
+            new Lazy<HttpClient>(() => new HttpClient());
+
+        // NOTE: This will always return the same HttpClient instance.
+        public HttpClient CreateClient(string name) => _httpClientLazy.Value;
+
+        public static IHttpClientFactory GetInstance() => _httpClientFactoryLazy.Value;
+    }
+}

--- a/HADotNet.Core.Tests/LogbookTests.cs
+++ b/HADotNet.Core.Tests/LogbookTests.cs
@@ -1,31 +1,30 @@
-using HADotNet.Core;
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class LogbookTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private LogbookClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<LogbookClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveAllLogbookEntries()
         {
-            var client = ClientFactory.GetClient<LogbookClient>();
-
-            var logEntries = await client.GetLogbookEntries();
+            var logEntries = await Client.GetLogbookEntries();
 
             Assert.IsNotNull(logEntries);
             Assert.IsNotEmpty(logEntries[0].EntityId);
@@ -36,9 +35,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveLogbookEntriesByEntityId()
         {
-            var client = ClientFactory.GetClient<LogbookClient>();
-
-            var history = await client.GetLogbookEntries("light.jakes_office");
+            var history = await Client.GetLogbookEntries("light.jakes_office");
 
             Assert.IsNotNull(history);
             Assert.IsNotEmpty(history.EntityId);
@@ -47,9 +44,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveLogbookEntriesByStartDate()
         {
-            var client = ClientFactory.GetClient<LogbookClient>();
-
-            var logEntries = await client.GetLogbookEntries(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)));
+            var logEntries = await Client.GetLogbookEntries(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)));
 
             Assert.IsNotNull(logEntries);
             Assert.IsNotEmpty(logEntries[0].EntityId);
@@ -60,9 +55,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveLogbookEntriesByStartAndEndDate()
         {
-            var client = ClientFactory.GetClient<LogbookClient>();
-
-            var logEntries = await client.GetLogbookEntries(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
+            var logEntries = await Client.GetLogbookEntries(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
 
             Assert.IsNotNull(logEntries);
             Assert.IsNotEmpty(logEntries[0].EntityId);
@@ -73,9 +66,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveLogbookEntriesByStartDateAndDuration()
         {
-            var client = ClientFactory.GetClient<LogbookClient>();
-
-            var logEntries = await client.GetLogbookEntries(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), TimeSpan.FromHours(18));
+            var logEntries = await Client.GetLogbookEntries(DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), TimeSpan.FromHours(18));
 
             Assert.IsNotNull(logEntries);
             Assert.IsNotEmpty(logEntries[0].EntityId);
@@ -86,9 +77,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveLogbookEntriesByStartAndEndDateAndEntityId()
         {
-            var client = ClientFactory.GetClient<LogbookClient>();
-
-            var history = await client.GetLogbookEntries("group.family_room_lights", DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
+            var history = await Client.GetLogbookEntries("group.family_room_lights", DateTimeOffset.Now.Subtract(TimeSpan.FromDays(2)), DateTimeOffset.Now.Subtract(new TimeSpan(1, 12, 0, 0)));
 
             Assert.IsNotNull(history);
             Assert.IsNotEmpty(history.EntityId);

--- a/HADotNet.Core.Tests/RootApiTests.cs
+++ b/HADotNet.Core.Tests/RootApiTests.cs
@@ -1,30 +1,30 @@
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class RootApiTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private RootApiClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<RootApiClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveRootApiMessage()
         {
-            var client = ClientFactory.GetClient<RootApiClient>();
-
-            var message = await client.GetStatusMessage();
+            var message = await Client.GetStatusMessage();
 
             Assert.IsNotEmpty(message.Message);
             Assert.AreEqual("API running.", message.Message);

--- a/HADotNet.Core.Tests/ServiceTests.cs
+++ b/HADotNet.Core.Tests/ServiceTests.cs
@@ -1,30 +1,30 @@
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class ServiceTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private ServiceClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<ServiceClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveServiceList()
         {
-            var client = ClientFactory.GetClient<ServiceClient>();
-
-            var services = await client.GetServices();
+            var services = await Client.GetServices();
 
             Assert.IsNotNull(services);
             Assert.AreNotEqual(0, services.Count);
@@ -33,9 +33,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldCallService()
         {
-            var client = ClientFactory.GetClient<ServiceClient>();
-
-            var returnState = await client.CallService("light.turn_on", new { entity_id = "light.sample_light" });
+            var returnState = await Client.CallService("light.turn_on", new { entity_id = "light.sample_light" });
 
             Assert.IsNotNull(returnState);
 
@@ -46,9 +44,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldCallServiceWithEntityId()
         {
-            var client = ClientFactory.GetClient<ServiceClient>();
-
-            var returnState = await client.CallServiceForEntities("light.turn_on", "light.my_light_1");
+            var returnState = await Client.CallServiceForEntities("light.turn_on", "light.my_light_1");
 
             Assert.IsNotNull(returnState);
 
@@ -59,9 +55,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldCallServiceWithEntityIds()
         {
-            var client = ClientFactory.GetClient<ServiceClient>();
-
-            var returnState = await client.CallServiceForEntities("light.turn_on", "light.my_light_1", "light.my_light_2");
+            var returnState = await Client.CallServiceForEntities("light.turn_on", "light.my_light_1", "light.my_light_2");
 
             Assert.IsNotNull(returnState);
 

--- a/HADotNet.Core.Tests/StatesTests.cs
+++ b/HADotNet.Core.Tests/StatesTests.cs
@@ -1,31 +1,31 @@
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class StatesTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private StatesClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<StatesClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveStateList()
         {
-            var client = ClientFactory.GetClient<StatesClient>();
-
-            var states = await client.GetStates();
+            var states = await Client.GetStates();
 
             Assert.IsNotNull(states);
             Assert.AreNotEqual(0, states.Count);
@@ -34,9 +34,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveState()
         {
-            var client = ClientFactory.GetClient<StatesClient>();
-
-            var state = await client.GetState("sun.sun");
+            var state = await Client.GetState("sun.sun");
 
             Assert.IsNotNull(state);
             Assert.IsNotEmpty(state.State);
@@ -45,9 +43,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveStateAttributeValue()
         {
-            var client = ClientFactory.GetClient<StatesClient>();
-
-            var state = await client.GetState("sun.sun");
+            var state = await Client.GetState("sun.sun");
 
             Assert.IsNotNull(state);
             Assert.AreEqual("Sun", state.GetAttributeValue<string>("friendly_name"));
@@ -56,9 +52,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldSetState()
         {
-            var client = ClientFactory.GetClient<StatesClient>();
-
-            var state = await client.SetState("sensor.hadotnet_test_entity", "testing");
+            var state = await Client.SetState("sensor.hadotnet_test_entity", "testing");
 
             Assert.IsNotNull(state);
             Assert.AreEqual("testing", state.State);
@@ -67,9 +61,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldSetStateWithAttributes()
         {
-            var client = ClientFactory.GetClient<StatesClient>();
-
-            var state = await client.SetState("sensor.hadotnet_test_entity", "testing",
+            var state = await Client.SetState("sensor.hadotnet_test_entity", "testing",
                 new Dictionary<string, object>
                 {
                     ["source"] = "HADotNet",

--- a/HADotNet.Core.Tests/StatsTests.cs
+++ b/HADotNet.Core.Tests/StatsTests.cs
@@ -1,30 +1,30 @@
 ﻿using System;
 using System.Threading.Tasks;
 using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
 using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class StatsTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private StatsClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<StatsClient>();
         }
 
         [Test]
         public async Task ShouldRetrieveSupervisorStats()
         {
-            var client = ClientFactory.GetClient<StatsClient>();
-
-            var stats = await client.GetSupervisorStats();
+            var stats = await Client.GetSupervisorStats();
 
             Assert.AreEqual("ok", stats.Result);
             Assert.IsNotNull(stats.Data);
@@ -33,9 +33,7 @@ namespace HADotNet.Core.Tests
         [Test]
         public async Task ShouldRetrieveCoreStats()
         {
-            var client = ClientFactory.GetClient<StatsClient>();
-
-            var stats = await client.GetCoreStats();
+            var stats = await Client.GetCoreStats();
 
             Assert.AreEqual("ok", stats.Result);
             Assert.IsNotNull(stats.Data);

--- a/HADotNet.Core.Tests/TemplateTests.cs
+++ b/HADotNet.Core.Tests/TemplateTests.cs
@@ -1,32 +1,31 @@
-using HADotNet.Core;
-using HADotNet.Core.Clients;
-using NUnit.Framework;
 using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using HADotNet.Core.Clients;
+using HADotNet.Core.Tests.Infrastructure;
+using NUnit.Framework;
 
 namespace HADotNet.Core.Tests
 {
     public class TemplateTests
     {
-        private Uri Instance { get; set; }
-        private string ApiKey { get; set; }
+        private TemplateClient Client { get; set; }
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
-            Instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
-            ApiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
+            var instance = new Uri(Environment.GetEnvironmentVariable("HADotNet:Tests:Instance"));
+            var apiKey = Environment.GetEnvironmentVariable("HADotNet:Tests:ApiKey");
 
-            ClientFactory.Initialize(Instance, ApiKey);
+            ClientFactory.Initialize(instance, apiKey, DefaultHttpClientFactory.GetInstance());
+
+            Client = ClientFactory.GetClient<TemplateClient>();
         }
 
         [Test]
         public async Task ShouldRenderSunTemplate()
         {
-            var client = ClientFactory.GetClient<TemplateClient>();
-
-            var result = await client.RenderTemplate("The sun is {{ states('sun.sun') }}");
+            var result = await Client.RenderTemplate("The sun is {{ states('sun.sun') }}");
 
             Assert.IsNotNull(result);
             Assert.IsTrue(Regex.IsMatch(result, "^The sun is (?:above_horizon|below_horizon)$"));

--- a/HADotNet.Core/Clients/AutomationClient.cs
+++ b/HADotNet.Core/Clients/AutomationClient.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using HADotNet.Core.Models;
-using Newtonsoft.Json;
 
 namespace HADotNet.Core.Clients
 {
@@ -15,7 +15,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public AutomationClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public AutomationClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Create the <see cref="AutomationObject"/>.

--- a/HADotNet.Core/Clients/CalendarClient.cs
+++ b/HADotNet.Core/Clients/CalendarClient.cs
@@ -1,7 +1,8 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -15,7 +16,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public CalendarClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public CalendarClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of current and future calendar items, from now until the specified <paramref name="daysFromNow" />. The maximum number of results is driven by the "max_results" configuration option in the calendar config.

--- a/HADotNet.Core/Clients/ConfigClient.cs
+++ b/HADotNet.Core/Clients/ConfigClient.cs
@@ -1,6 +1,7 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -14,7 +15,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public ConfigClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public ConfigClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves the current Home Assistant configuration object.

--- a/HADotNet.Core/Clients/DiscoveryClient.cs
+++ b/HADotNet.Core/Clients/DiscoveryClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using HADotNet.Core.Models;
 
@@ -14,7 +15,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public DiscoveryClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public DiscoveryClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves the current Home Assistant discovery object.

--- a/HADotNet.Core/Clients/EntityClient.cs
+++ b/HADotNet.Core/Clients/EntityClient.cs
@@ -1,8 +1,9 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -16,7 +17,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public EntityClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public EntityClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of all current entity names (that have state) in the format "domain.name".

--- a/HADotNet.Core/Clients/ErrorLogClient.cs
+++ b/HADotNet.Core/Clients/ErrorLogClient.cs
@@ -1,7 +1,7 @@
-﻿using HADotNet.Core.Models;
-using System;
-using System.Collections.Generic;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -15,7 +15,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public ErrorLogClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public ErrorLogClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of error log entries.

--- a/HADotNet.Core/Clients/EventClient.cs
+++ b/HADotNet.Core/Clients/EventClient.cs
@@ -1,7 +1,8 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -15,7 +16,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public EventClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public EventClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves the current Home Assistant configuration object.

--- a/HADotNet.Core/Clients/HistoryClient.cs
+++ b/HADotNet.Core/Clients/HistoryClient.cs
@@ -1,8 +1,9 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -16,7 +17,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public HistoryClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public HistoryClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of ALL historical states for all entities for the past 1 day. WARNING: On larger HA installs, this can return 300+ entities, over 4 MB of data, and take 20+ seconds.

--- a/HADotNet.Core/Clients/InfoClient.cs
+++ b/HADotNet.Core/Clients/InfoClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using HADotNet.Core.Domain;
 using HADotNet.Core.Models;
@@ -15,7 +16,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public InfoClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public InfoClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves Supervisor information.

--- a/HADotNet.Core/Clients/LogbookClient.cs
+++ b/HADotNet.Core/Clients/LogbookClient.cs
@@ -1,8 +1,9 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -16,7 +17,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public LogbookClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public LogbookClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of ALL logbook states for all entities for the past 1 day.

--- a/HADotNet.Core/Clients/RootApiClient.cs
+++ b/HADotNet.Core/Clients/RootApiClient.cs
@@ -1,6 +1,7 @@
-﻿using HADotNet.Core.Models;
-using System;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using HADotNet.Core.Models;
 
 namespace HADotNet.Core.Clients
 {
@@ -14,7 +15,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public RootApiClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public RootApiClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves the API status message for the Home Assistant instance, to ensure it is running.

--- a/HADotNet.Core/Clients/ServiceClient.cs
+++ b/HADotNet.Core/Clients/ServiceClient.cs
@@ -1,6 +1,7 @@
 ﻿using HADotNet.Core.Models;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace HADotNet.Core.Clients
@@ -15,7 +16,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public ServiceClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public ServiceClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of current services, separated into service domains.

--- a/HADotNet.Core/Clients/StatesClient.cs
+++ b/HADotNet.Core/Clients/StatesClient.cs
@@ -1,6 +1,7 @@
 ﻿using HADotNet.Core.Models;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace HADotNet.Core.Clients
@@ -15,7 +16,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public StatesClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public StatesClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves a list of current entities and their states.

--- a/HADotNet.Core/Clients/StatsClient.cs
+++ b/HADotNet.Core/Clients/StatsClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using HADotNet.Core.Models;
 
@@ -14,7 +15,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public StatsClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public StatsClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Retrieves Supervisor information.

--- a/HADotNet.Core/Clients/TemplateClient.cs
+++ b/HADotNet.Core/Clients/TemplateClient.cs
@@ -1,7 +1,5 @@
-﻿using HADotNet.Core.Models;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace HADotNet.Core.Clients
@@ -16,7 +14,8 @@ namespace HADotNet.Core.Clients
         /// </summary>
         /// <param name="instance">The Home Assistant base instance URL.</param>
         /// <param name="apiKey">The Home Assistant long-lived access token.</param>
-        public TemplateClient(Uri instance, string apiKey) : base(instance, apiKey) { }
+        /// <param name="httpClient">The Http client.</param>
+        public TemplateClient(Uri instance, string apiKey, HttpClient httpClient) : base(instance, apiKey, httpClient) { }
 
         /// <summary>
         /// Renders a template and returns the resulting output as a string.

--- a/HADotNet.Core/HADotNet.Core.csproj
+++ b/HADotNet.Core/HADotNet.Core.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/HADotNet.Core/Models/StatsObject.cs
+++ b/HADotNet.Core/Models/StatsObject.cs
@@ -47,12 +47,12 @@ namespace HADotNet.Core.Models
         /// Gets or sets the network rx.
         /// </summary>
         [JsonProperty("network_rx")]
-        public int NetworkRx { get; set; }
+        public long NetworkRx { get; set; }
 
         /// <summary>
         /// Gets or sets the network tx.
         /// </summary>
         [JsonProperty("network_tx")]
-        public int NetworkTx { get; set; }
+        public long NetworkTx { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,12 +51,25 @@ or build the project and include the DLL as a reference.
 The `ClientFactory` class is reponsible for initializing all other clients in a 
 reusable way, so you only have to define your instance URL and API key once.
 
-To initialize the `ClientFactory`, pass in your base Home Assistant URL and a
-long-lived access token that you created on your profile page.
+To initialize the `ClientFactory`, first you need to make sure that `IHttpClientFactory` is configured by adding the following line in `Startup.cs` file:
 
 ```csharp
-ClientFactory.Initialize("https://my-home-assistant-url/", "AbCdEf0123456789...");
+public void ConfigureServices(IServiceCollection services)
+{
+	services.AddHttpClient();
+}
 ```
+
+The pass in your base Home Assistant URL, a long-lived access token that you created on your profile page and resolved `IHttpClientFactory`:
+
+```csharp
+ClientFactory.Initialize("https://my-home-assistant-url/", "AbCdEf0123456789...", httpClientFactory);
+```
+
+Learn more how to [Use IHttpClientFactory to implement resilient HTTP requests](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests).
+
+You can also take a look at [Implement HTTP call retries with exponential backoff with IHttpClientFactory and Polly policies](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly) for retry mechanism.
+
 
 ### Getting Home Assistant's Current Configuration
 


### PR DESCRIPTION
Hi @qJake , @Devqon,

I made another attempt after taking inspiration from the following articles:
* https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
* https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#consumption-patterns
* https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly

So in short I think we should use IHttpClientFactory as suggested by Microsoft developers. In this case we can add retry mechanism easily using [Polly library](https://github.com/App-vNext/Polly).

I tried to polish all the changes so this should be ready to merged, but please let me know if you find somethings.

Thanks